### PR TITLE
avoid crashing if node does not exist

### DIFF
--- a/scripts/buildGraphs.py
+++ b/scripts/buildGraphs.py
@@ -192,8 +192,8 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
             out_jets_eta = np.array([], dtype=dtype)
             out_jets_phi = np.array([], dtype=dtype)
             out_jets_feats = [np.array([], dtype=dtype) for i in range(nFeats)]
-            out_jets_node1 = np.array([], dtype=itype)
-            out_jets_node2 = np.array([], dtype=itype)
+            out_jets_node1 = np.ndarray((0,0), dtype=itype)
+            out_jets_node2 = np.ndarray((0,0), dtype=itype)
         ###
 
         ## Do the processing


### PR DESCRIPTION
dR=0.0 일때 buildGraph에 문제가 있었음.

```
@@@ Checking input files... (total 420 files)
@@@ Total 15466225 events to process, store 16384 events per file
@@@ Start processing...
Traceback (most recent call last):
  File "../scripts/buildGraphs.py", line 219, in <module>
    out_jets_node1 = np.concatenate([out_jets_node1, np.array([list(x) for x in jets_node1[begin:end]], dtype=itype)])
  File "<__array_function__ internals>", line 6, in concatenate
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 1 dimension(s) and the array at index 1 has 2 dimension(s)
```

node1 array 초기화시 shape을 (0,0)으로 2 dimension으로 명시하여 미리 지정하는 방식으로 해결함.