### PR TITLE
Bugfix to work with sparse case

### DIFF
--- a/run/run_eval.py
+++ b/run/run_eval.py
@@ -57,9 +57,10 @@ print("Load saved model from", (args.input+'/model.pth'))
 model = torch.load(args.input+'/model.pth')
 
 device = 'cpu'
-if torch.cuda.is_available():
-  model = model.cuda()
-  device = 'cuda'
+if args.device >= 0 and torch.cuda.is_available():
+    torch.cuda.set_device(args.device)
+    model = model.cuda()
+    device = 'cuda'
 print('done')
 
 model.load_state_dict(torch.load(args.input+'/weight.pth', map_location='cpu'))

--- a/scripts/buildGraphs.py
+++ b/scripts/buildGraphs.py
@@ -201,23 +201,14 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
         nEventToGo -= (end-begin)
 
         out_weights = np.concatenate([out_weights, src_weights[begin:end]])
-        if (end-begin) <= 1: ## Exceptional case: np.array mistakes output shape to be (1,N) of float type but we need (1,) of list type
-            out_jets_eta = np.concatenate([out_jets_eta, np.array([[src_jets_eta[begin]],[]], dtype=dtype)])[:-1]
-            out_jets_phi = np.concatenate([out_jets_phi, np.array([[src_jets_phi[begin]],[]], dtype=dtype)])[:-1]
-            for i in range(nFeats):
-                out_jets_feats[i] = np.concatenate([out_jets_feats[i],
-                                                    np.array([[src_jets_feats[i][begin]],[]], dtype=dtype)])[:-1]
-            out_jets_node1 = np.concatenate([out_jets_node1, np.array([[jets_node1[begin]],[]], dtype=itype)])[:-1]
-            out_jets_node2 = np.concatenate([out_jets_node2, np.array([[jets_node2[begin]],[]], dtype=itype)])[:-1]
-
-        else:
-            out_jets_eta = np.concatenate([out_jets_eta, np.array([list(x) for x in src_jets_eta[begin:end]], dtype=dtype)])
-            out_jets_phi = np.concatenate([out_jets_phi, np.array([list(x) for x in src_jets_phi[begin:end]], dtype=dtype)])
-            for i in range(nFeats):
-                out_jets_feats[i] = np.concatenate([out_jets_feats[i],
-                                                    np.array([list(x) for x in src_jets_feats[i][begin:end]], dtype=dtype)])
-            out_jets_node1 = np.concatenate([out_jets_node1, np.array([list(x) for x in jets_node1[begin:end]], dtype=itype)])
-            out_jets_node2 = np.concatenate([out_jets_node2, np.array([list(x) for x in jets_node2[begin:end]], dtype=itype)])
+        ## Add dummy list and pop back - np.array mistakes output shape to be (1,N) of float type but we need (1,) of list type
+        out_jets_eta = np.concatenate([out_jets_eta, np.array([[src_jets_eta[begin:end]],[]], dtype=dtype)])[:-1]
+        out_jets_phi = np.concatenate([out_jets_phi, np.array([[src_jets_phi[begin:end]],[]], dtype=dtype)])[:-1]
+        for i in range(nFeats):
+            out_jets_feats[i] = np.concatenate([out_jets_feats[i],
+                                                np.array([[src_jets_feats[i][begin:end]],[]], dtype=dtype)])[:-1]
+        out_jets_node1 = np.concatenate([out_jets_node1, np.array([[jets_node1[begin:end]],[]], dtype=itype)])[:-1]
+        out_jets_node2 = np.concatenate([out_jets_node2, np.array([[jets_node2[begin:end]],[]], dtype=itype)])[:-1]
 
         begin, end = end, min(nEventToGo, nEventPassed)
 


### PR DESCRIPTION
There were some failures in low hT samples, reported by @photoeru 

```File "buildGraphs.py", line 210, in <module>
    out_jets_node1 = np.concatenate([out_jets_node1, np.array([[jets_node1[begin]],[]], dtype=itype)])[:-1]
  File "<__array_function__ internals>", line 6, in concatenate
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 2 dimension(s) and the array at index 1 has 1 dimension(s)```